### PR TITLE
Passes dimension resources to first func instead

### DIFF
--- a/sql/Shard.go
+++ b/sql/Shard.go
@@ -21,7 +21,7 @@ type Shard struct {
 		Query(query string, args ...interface{}) (*sql.Rows, error)
 	}
 	BeginEndHandler func() (func(), error)
-	MetricsHandler  func() func(query string, shardName string)
+	MetricsHandler  func(query string, shardName string) func()
 }
 
 func (s *Shard) Transact(txFun TxFunc) errs.Err {
@@ -85,7 +85,7 @@ func (s *Shard) Query(query string, args ...interface{}) (*sql.Rows, errs.Err) {
 		defer doneFunc()
 	}
 	if s.MetricsHandler != nil {
-		defer s.MetricsHandler()(query, s.DBName)
+		defer s.MetricsHandler(query, s.DBName)()
 	}
 	fixArgs(args)
 	rows, stdErr := s.sqlConn.Query(query, args...)
@@ -105,7 +105,7 @@ func (s *Shard) Exec(query string, args ...interface{}) (sql.Result, errs.Err) {
 		defer doneFunc()
 	}
 	if s.MetricsHandler != nil {
-		defer s.MetricsHandler()(query, s.DBName)
+		defer s.MetricsHandler(query, s.DBName)()
 	}
 	fixArgs(args)
 	res, stdErr := s.sqlConn.Exec(query, args...)

--- a/sql/ShardSet.go
+++ b/sql/ShardSet.go
@@ -23,7 +23,7 @@ type ShardSet struct {
 	maxConns        int
 	shards          []*Shard
 	beginEndHandler func() (func(), error)
-	metricsHandler  func() func(query string, shardName string)
+	metricsHandler  func(query string, shardName string) func()
 	log             *log.Logger
 }
 
@@ -32,7 +32,7 @@ func WithBeginEndHandler(handler func() (func(), error)) func(*ShardSet) {
 		s.beginEndHandler = handler
 	}
 }
-func WithMetricsHandler(handler func() func(string, string)) func(*ShardSet) {
+func WithMetricsHandler(handler func(query string, shardName string) func()) func(*ShardSet) {
 	return func(s *ShardSet) {
 		s.metricsHandler = handler
 	}

--- a/sql/ShardSet_test.go
+++ b/sql/ShardSet_test.go
@@ -20,16 +20,16 @@ func TestNewShardSetWithNoBeginEndHandler(t *testing.T) {
 	assert.Nil(t, n.beginEndHandler)
 }
 func TestNewShardSetWithMetricsHandler(t *testing.T) {
-	f := func() func(string, string) {
-		return func(string, string) {}
+	f := func(string, string) func() {
+		return func() {}
 	}
 	n := NewShardSet("test", "test", "test", 9999, "test", 9999, 9999, 9999, WithMetricsHandler(f))
 	assert.NotEmpty(t, n)
 	assert.NotNil(t, n.metricsHandler)
 }
 func TestNewShardSetWithBothHandlers(t *testing.T) {
-	metricsHandler := func() func(string, string) {
-		return func(string, string) {}
+	metricsHandler := func(string, string) func() {
+		return func() {}
 	}
 	beginEndHandler := func() (func(), error) {
 		return func() {}, nil

--- a/sql/Shard_test.go
+++ b/sql/Shard_test.go
@@ -20,7 +20,7 @@ func (dbcb *mockCircuitBreaker) CircuitBreakerHandler() (func(), error) {
 
 type mockShard struct {
 	BeginEndHandler func() (func(), error)
-	MetricsHandler  func() func(string, string)
+	MetricsHandler  func(string, string) func()
 }
 
 func (s *mockShard) Transact(txFun TxFunc) error {
@@ -78,7 +78,7 @@ type mockMetricsCollector struct {
 	numCalled int
 }
 
-func (hist *mockMetricsCollector) HistogramHandler() func(string, string) {
+func (hist *mockMetricsCollector) HistogramHandler(string, string) func() {
 	hist.numCalled++
 	return nil
 }


### PR DESCRIPTION
Instead of passing the source for deriving dimension in metrics to the
function executed at the end of the operation, passes the same
information to the function executed at the beginning. This allows an
attemts count in addition to the duration observation.