### PR TITLE
[CB-3008] Setting max idle to be half of max connection

### DIFF
--- a/sql/ShardSet.go
+++ b/sql/ShardSet.go
@@ -133,7 +133,7 @@ func newShard(s *ShardSet, dbName string, autoIncrementOffset int) (*Shard, errs
 	}
 
 	db.SetMaxOpenConns(s.maxConns)
-	// db.SetMaxIdleConns(n)
+	db.SetMaxIdleConns(s.maxConns / 2)
 	stdErr := db.Ping()
 	if stdErr != nil {
 		return nil, errs.Wrap(stdErr, nil)

--- a/sql/ShardSet.go
+++ b/sql/ShardSet.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/marcuswestin/fun-go/errs"
 	"github.com/marcuswestin/fun-go/random"
@@ -134,6 +135,7 @@ func newShard(s *ShardSet, dbName string, autoIncrementOffset int) (*Shard, errs
 
 	db.SetMaxOpenConns(s.maxConns)
 	db.SetMaxIdleConns(s.maxConns / 2)
+	db.SetConnMaxLifetime(30 * time.Minute)
 	stdErr := db.Ping()
 	if stdErr != nil {
 		return nil, errs.Wrap(stdErr, nil)


### PR DESCRIPTION
After looking at the total number of db connection from AWS console, it became very clear that we are not maxing out on to database connections during high load.  Instead we are frequently dropping connection and reconnecting, because the default max idle is 2.  The extra cost of reconnecting is slowing down our database queries significantly.  This PR sets the max idle to half of the max connection, and set ConnMaxLifetime to 30 minutes so connection can stay around longer.  This has already produced significant reduction in overall query time in lima low test environment.

Before
<img width="1350" alt="Screen Shot 2019-08-09 at 4 00 01 PM" src="https://user-images.githubusercontent.com/30121162/62805969-81c1ea80-babf-11e9-9032-72a43df9d340.png">

After
<img width="1341" alt="Screen Shot 2019-08-09 at 4 04 57 PM" src="https://user-images.githubusercontent.com/30121162/62805974-84bcdb00-babf-11e9-8328-7b13415382e9.png">


Reference: https://making.pusher.com/production-ready-connection-pooling-in-go/

@dcodix @patoarvizu this is likely to raise the concurrent db connection level for RDS.  I will do some measurement and adjust db alerts accordingly